### PR TITLE
Redesign interface and impl to fix unexpected behavior around step count

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true">
         <service
-            android:name=".util.SensorListener"
+            android:name=".SensorListener"
             android:exported="true" />
 
         <receiver android:name=".BootReceiver">

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         android:supportsRtl="true">
         <service
             android:name=".SensorListener"
-            android:exported="true" />
+            android:exported="false" />
 
         <receiver android:name=".BootReceiver">
             <intent-filter>

--- a/src/main/java/com/sukesan1984/stepsensorlib/BootReceiver.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/BootReceiver.java
@@ -4,36 +4,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-import com.sukesan1984.stepsensorlib.util.DateUtils;
-import com.sukesan1984.stepsensorlib.util.Logger;
-import com.sukesan1984.stepsensorlib.util.SensorListener;
-
-/**
- * Created by kosuketakami on 2016/11/05.
- */
-
 public class BootReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-        Database db = Database.getInstance(context);
-
-        if (!PreferenceManager.readCorrectShutDown(context, false)) {
-            if (BuildConfig.DEBUG) {
-                Logger.log("Incorrect shutdown");
-            }
-            int steps = db.getLastUpdatedSteps();
-            if (BuildConfig.DEBUG) {
-                Logger.log("Trying to recover " + steps + " steps");
-            }
-            db.updateOrInsert(DateUtils.getCurrentDateAndHour(), steps);
-        }
-        // last entry might still have a negative step value, so remove that
-        // row if that's the case
-        db.removeNegativeEntries();
-        db.close();
-
-        PreferenceManager.deleteCorrectShutDown(context);
-        PreferenceManager.deleteStepsSinceBoot(context);
         context.startService(new Intent(context, SensorListener.class));
     }
 }

--- a/src/main/java/com/sukesan1984/stepsensorlib/Database.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/Database.java
@@ -15,17 +15,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- *
- */
-
-public class Database extends SQLiteOpenHelper {
+class Database extends SQLiteOpenHelper {
     private final static String TABLE_NAME = "steps";
     private final static String COLUMN_DATE_AND_HOUR = "date_and_hour";
     private final static String COLUMN_STEPS = "steps";
     private final static String COLUMN_IS_RECORDED_ON_SERVER = "is_recorded_on_server";
     private final static String COLUMN_LAST_UPDATED = "last_updated";
-    private final static int DB_VERSION = 1;
+    private final static int DB_VERSION = 2;
 
     private static Database instance;
     private static final AtomicInteger openCounter = new AtomicInteger();
@@ -82,46 +78,31 @@ public class Database extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        // on upgrade
-    }
-
-    /**
-     * Query the 'steps' table. Remember to close the cursor!
-     *
-     * @param columns       the colums
-     * @param selection     the selection
-     * @param selectionArgs the selction arguments
-     * @param groupBy       the group by statement
-     * @param having        the having statement
-     * @param orderBy       the order by statement
-     * @return the cursor
-     */
-    public Cursor query(final String[] columns, final String selection,
-                        final String[] selectionArgs, final String groupBy, final String having,
-                        final String orderBy, final String limit) {
-        try {
-            return getReadableDatabase()
-                    .query(TABLE_NAME, columns, selection, selectionArgs, groupBy, having, orderBy, limit);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
+        if (oldVersion < 2) {
+            db.delete("steps", "date_and_hour = ?", new String[]{"-1"});
         }
     }
 
     /**
-     * @param dateAndHour    the dateAndHour in ms since 1970
-     * @param stepsSinceBoot the steps since boot
+     * Add step count in table. If no row matching to targetDateAndHour is exist, it will be created.
+     *
+     * @param targetDateAndHour Key for table.
+     * @param stepsToAdd        Count to be added.
+     * @throws IllegalArgumentException if stepsToAdd is negative value.
      */
-    public void updateOrInsert(long dateAndHour, int stepsSinceBoot) {
+    public boolean addSteps(long targetDateAndHour, int stepsToAdd) {
+        if (stepsToAdd < 0) throw new IllegalArgumentException("stepsToAdd should not be negative value.");
         SQLiteDatabase db = null;
         try {
             db = getWritableDatabase();
             db.beginTransaction();
-            updateOrInsertWithoutTransaction(db, dateAndHour, stepsSinceBoot);
+            int currentSteps = getStepsImpl(db, targetDateAndHour);
+            insertOrReplaceStepRow(db, targetDateAndHour, currentSteps + stepsToAdd, true);
             db.setTransactionSuccessful();
-
+            return true;
         } catch (Exception e) {
             e.printStackTrace();
+            return false;
         } finally {
             if (db != null) {
                 db.endTransaction();
@@ -130,149 +111,27 @@ public class Database extends SQLiteOpenHelper {
         }
     }
 
-    private void updateOrInsertWithoutTransaction(SQLiteDatabase db, long dateAndHour, int stepsSinceBoot) {
-        if (db == null) {
-            return;
-        }
-        Cursor c = getByDateAndHour(dateAndHour);
-        if (c == null) {
-            return;
-        }
-        initializeLastUpdatedSteps(db, stepsSinceBoot);
-        int lastUpdatedSteps = getLastUpdatedSteps();
-        if (lastUpdatedSteps > stepsSinceBoot) {
-            saveLastUpdatedSteps(db, stepsSinceBoot);
-            return;
-        }
-
-        int addedSteps = stepsSinceBoot - lastUpdatedSteps;
-        if (c.getCount() == 0 && stepsSinceBoot >= 0) {
-            insertNewDateAndHour(db, dateAndHour, addedSteps);
-        } else {
-            addToLastEntry(db, addedSteps);
-        }
-        saveLastUpdatedSteps(db, stepsSinceBoot);
-        c.close();
-    }
-
-    /**
-     * replace steps count if steps is larger than current databace value.
-     *
-     * @param dateAndHour
-     * @param steps
-     */
-    public void insertOrReplaceSteps(final long dateAndHour, final int steps) {
-        SQLiteDatabase db = null;
-        Cursor c = null;
-        try {
-            db = getWritableDatabase();
-            c = getByDateAndHour(dateAndHour);
-            db.beginTransaction();
-            if (c == null) {
-                db.endTransaction();
-                db.close();
-                return;
-            }
-            if (c.getCount() == 0) {
-                if (steps > 0) {
-                    insertNewDateAndHour(db, dateAndHour, steps);
-                } else {
-                    return;
-                }
-            } else if (c.moveToFirst() && c.getInt(0) < steps) {
-                Logger.log("#### update");
-                Logger.log("#### data_and_hour: " + dateAndHour);
-                Logger.log("#### steps: " + steps);
-                ContentValues values = new ContentValues();
-                values.put(COLUMN_DATE_AND_HOUR, dateAndHour);
-                values.put(COLUMN_STEPS, steps);
-                values.put(COLUMN_LAST_UPDATED, DateUtils.getCurrentTimeMllis());
-                db.update(TABLE_NAME, values,
-                        COLUMN_DATE_AND_HOUR + " = ?",
-                        new String[]{String.valueOf(dateAndHour)});
-            }
-            db.setTransactionSuccessful();
-
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            if (c != null) {
-                c.close();
-            }
-            if (db != null) {
-                db.endTransaction();
-                db.close();
-            }
-        }
-
-    }
-
-    /**
-     * Inserts a new entry in the database, if there is no entry for the given
-     * dateAndHour yet.
-     * <p/>
-     *
-     * @param dateAndHour the dateAndHour in ms since 1970
-     * @param steps       the current step value
-     */
-
-    private void insertNewDateAndHour(SQLiteDatabase db, final long dateAndHour, final int steps) {
-        Logger.log("insert new date and hour");
-        Logger.log("date_and_hour: " + dateAndHour);
-        Logger.log("steps: " + steps);
+    private void insertOrReplaceStepRow(SQLiteDatabase db, long dateAndHour, int steps, boolean markNotRecorded) {
         ContentValues values = new ContentValues();
         values.put(COLUMN_DATE_AND_HOUR, dateAndHour);
-        // use the negative steps as offset
         values.put(COLUMN_STEPS, steps);
         values.put(COLUMN_LAST_UPDATED, DateUtils.getCurrentTimeMllis());
-        db.insert(TABLE_NAME, null, values);
-        if (BuildConfig.DEBUG) {
-            Logger.log("insertDayAndHour" + dateAndHour + " / " + steps);
-            logState();
+        if (markNotRecorded) {
+            values.put(COLUMN_IS_RECORDED_ON_SERVER, 0);
         }
+        db.replaceOrThrow(TABLE_NAME, null, values);
     }
 
-    private Cursor getByDateAndHour(long dateAndHour) {
-        try {
-            return getReadableDatabase().query(TABLE_NAME, new String[]{COLUMN_STEPS},
-                    COLUMN_DATE_AND_HOUR + " = ?",
-                    new String[]{String.valueOf(dateAndHour)}, null, null, null);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-
-    }
-
-    private void addToLastEntry(SQLiteDatabase db, int steps) {
-        if (steps > 0) {
-            db.execSQL("UPDATE " + TABLE_NAME + " SET " + COLUMN_STEPS + " = " + COLUMN_STEPS + " + " + steps
-                    + ", " + COLUMN_IS_RECORDED_ON_SERVER + " = 0, " + COLUMN_LAST_UPDATED + " =" + DateUtils.getCurrentTimeMllis() +
-                    " WHERE " + COLUMN_DATE_AND_HOUR + "= (SELECT MAX(" + COLUMN_DATE_AND_HOUR + ") FROM " + TABLE_NAME + ");");
-        }
-    }
-
-    /**
-     * Writes the current steps database to the log.
-     */
-    public void logState() {
-        if (BuildConfig.DEBUG) {
-            Cursor c = getReadableDatabase()
-                    .query(TABLE_NAME, null, null, null, null, null, COLUMN_DATE_AND_HOUR + " DESC", null);
-            if (c != null) {
-                Logger.log(c);
-                c.close();
-            }
-        }
-    }
-
-    /**
-     * @param dateAndHour
-     * @return
-     */
     public int getSteps(final long dateAndHour) {
         Logger.log("getStep dateAndHour" + dateAndHour);
-        Cursor c = getByDateAndHour(dateAndHour);
+        SQLiteDatabase db = getReadableDatabase();
+        return getStepsImpl(db, dateAndHour);
+    }
+
+    private int getStepsImpl(SQLiteDatabase db, long dateAndHour) {
+        Cursor c = db.query(TABLE_NAME, new String[]{COLUMN_STEPS},
+                COLUMN_DATE_AND_HOUR + " = ?",
+                new String[]{String.valueOf(dateAndHour)}, null, null, null);
 
         if (c != null) {
             c.moveToFirst();
@@ -318,100 +177,23 @@ public class Database extends SQLiteOpenHelper {
         }
     }
 
-    public List<ChunkStepCount> getChunkStepsFrom(final long start) {
-        Cursor c = null;
+    @NonNull
+    public List<ChunkStepCount> getChunkStepsSince(final long start) {
+        Cursor c;
         try {
             c = getReadableDatabase()
                     .query(TABLE_NAME, new String[]{COLUMN_DATE_AND_HOUR, COLUMN_STEPS},
                             COLUMN_DATE_AND_HOUR + " >= ?", new String[]{String.valueOf(start)}, null, null, null);
 
             if (c == null) {
-                return null;
+                return new ArrayList<>();
             }
 
             return createChunkedStepCounts(c);
         } catch (Exception e) {
             e.printStackTrace();
-            return null;
+            return new ArrayList<>();
         }
-    }
-
-    /**
-     * Removes all entries with negative values.
-     * <p/>
-     * Only call this directly after boot, otherwise it might remove the current
-     * day as the current offset is likely to be negative.
-     */
-    void removeNegativeEntries() {
-        try {
-            getWritableDatabase().delete(TABLE_NAME, COLUMN_STEPS + " < ?", new String[]{"0"});
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    /**
-     * Remove invalid entries from the database.
-     * Currently, an invalid input is such with steps >= 200,000
-     */
-    public void removeInvalidEntries() {
-        try {
-            getWritableDatabase().delete(TABLE_NAME, COLUMN_STEPS + " >= ?", new String[]{"200000"});
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    /**
-     * @param stepsSinceBoot steps after boot.
-     */
-    public void resetLastUpdatedSteps(final int stepsSinceBoot) {
-        SQLiteDatabase db = null;
-        try {
-            db = getWritableDatabase();
-            db.beginTransaction();
-            updateOrInsertWithoutTransaction(db, DateUtils.getCurrentDateAndHour(), stepsSinceBoot);
-            saveLastUpdatedSteps(db, 0);
-            db.setTransactionSuccessful();
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            if (db != null) {
-                db.endTransaction();
-                db.close();
-            }
-        }
-    }
-
-    private void initializeLastUpdatedSteps(SQLiteDatabase db, final int stepsSinceBoot) {
-        if (db == null) {
-            return;
-        }
-        // initialize if there is no date
-        if (getSteps(-1) == Integer.MIN_VALUE) {
-            saveLastUpdatedSteps(db, stepsSinceBoot);
-        }
-    }
-
-    private void saveLastUpdatedSteps(SQLiteDatabase db, final int steps) {
-        if (db == null) {
-            return;
-        }
-        ContentValues values = new ContentValues();
-        values.put(COLUMN_STEPS, steps);
-        if (db.update(TABLE_NAME, values, COLUMN_DATE_AND_HOUR + " = -1", null) == 0) {
-            values.put(COLUMN_DATE_AND_HOUR, -1);
-            values.put(COLUMN_LAST_UPDATED, DateUtils.getCurrentTimeMllis());
-            db.insert(TABLE_NAME, null, values);
-        }
-        if (BuildConfig.DEBUG) {
-            Logger.log("saving steps in db: " + steps);
-        }
-    }
-
-    public int getLastUpdatedSteps() {
-        int currentSteps = getSteps(-1);
-        return currentSteps == Integer.MIN_VALUE ? 0 : currentSteps;
     }
 
     public int getTodayStep() {
@@ -420,7 +202,7 @@ public class Database extends SQLiteOpenHelper {
     }
 
     @NonNull
-    public List<ChunkStepCount> getNotRecordedChunkedStepCounts() {
+    public List<ChunkStepCount> getNotRecordedChunkStepCounts() {
         Cursor c = null;
         try {
             c = getReadableDatabase()
@@ -429,7 +211,7 @@ public class Database extends SQLiteOpenHelper {
                                     COLUMN_IS_RECORDED_ON_SERVER + " = ?", new String[]{"-1", "0"}, null, null, null);
             Logger.log("Not recoreded Chunk Size: " + c.getCount());
             if (c == null) {
-                return null;
+                return new ArrayList<>();
             }
             // cursor close is in method
             return createChunkedStepCounts(c);
@@ -438,7 +220,7 @@ public class Database extends SQLiteOpenHelper {
             if (c != null) {
                 c.close();
             }
-            return null;
+            return new ArrayList<>();
         }
     }
 
@@ -458,12 +240,12 @@ public class Database extends SQLiteOpenHelper {
         return lists;
     }
 
-    public void updateToRecorded(long[] dateAndHours) {
+    public void updateToRecorded(List<Long> dateAndHours) {
         SQLiteDatabase db = null;
         try {
             ContentValues values = new ContentValues();
             values.put(COLUMN_IS_RECORDED_ON_SERVER, "1");
-            int length = dateAndHours.length;
+            int length = dateAndHours.size();
             String args = "";
             String[] dateAndHoursString = new String[length];
             for (int i = 0; i < length; i++) {
@@ -472,14 +254,13 @@ public class Database extends SQLiteOpenHelper {
                 } else {
                     args += ", ?";
                 }
-                dateAndHoursString[i] = String.valueOf(dateAndHours[i]);
+                dateAndHoursString[i] = String.valueOf(dateAndHours.get(i));
             }
 
             db = getWritableDatabase();
             db.beginTransaction();
             int rows = db.update(TABLE_NAME, values, String.format(COLUMN_DATE_AND_HOUR + " in (%s)", args), dateAndHoursString);
             Logger.log("updated number: " + rows);
-            logState();
             db.setTransactionSuccessful();
             Logger.log("update to Recorded: " + dateAndHoursString.toString());
         } catch (Exception e) {
@@ -489,6 +270,30 @@ public class Database extends SQLiteOpenHelper {
                 db.endTransaction();
                 db.close();
             }
+        }
+    }
+
+    public void increaseByChunkStepCounts(List<ChunkStepCount> chunkStepCounts) {
+        SQLiteDatabase db = null;
+        try {
+            db = getWritableDatabase();
+            db.beginTransaction();
+            for (ChunkStepCount chunkStepCount : chunkStepCounts) {
+                increaseByChunkStepCount(db, chunkStepCount);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            if (db != null) {
+                db.endTransaction();
+                db.close();
+            }
+        }
+    }
+
+    private void increaseByChunkStepCount(SQLiteDatabase db, ChunkStepCount chunkStepCount) {
+        int currentSteps = getStepsImpl(db, chunkStepCount.unixTimeMillis);
+        if (chunkStepCount.steps > currentSteps) {
+            insertOrReplaceStepRow(db, chunkStepCount.unixTimeMillis, chunkStepCount.steps, false);
         }
     }
 }

--- a/src/main/java/com/sukesan1984/stepsensorlib/Database.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/Database.java
@@ -70,10 +70,6 @@ class Database extends SQLiteOpenHelper {
             db.delete(TABLE_NAME, "", new String[]{});
         } catch (Exception e) {
             e.printStackTrace();
-        } finally {
-            if (db != null) {
-                db.close();
-            }
         }
     }
 
@@ -109,7 +105,6 @@ class Database extends SQLiteOpenHelper {
         } finally {
             if (db != null) {
                 db.endTransaction();
-                db.close();
             }
         }
     }
@@ -268,7 +263,6 @@ class Database extends SQLiteOpenHelper {
         } finally {
             if (db != null) {
                 db.endTransaction();
-                db.close();
             }
         }
     }
@@ -285,7 +279,6 @@ class Database extends SQLiteOpenHelper {
         } finally {
             if (db != null) {
                 db.endTransaction();
-                db.close();
             }
         }
     }

--- a/src/main/java/com/sukesan1984/stepsensorlib/Database.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/Database.java
@@ -25,7 +25,6 @@ class Database extends SQLiteOpenHelper {
     private final static int DB_VERSION = 2;
 
     private static Database instance;
-    private static final AtomicInteger openCounter = new AtomicInteger();
 
     private Database(final Context context) {
         super(context, TABLE_NAME, null, DB_VERSION);
@@ -35,17 +34,7 @@ class Database extends SQLiteOpenHelper {
         if (instance == null) {
             instance = new Database(c.getApplicationContext());
         }
-
-        openCounter.incrementAndGet();
-
         return instance;
-    }
-
-    @Override
-    public void close() {
-        if (openCounter.decrementAndGet() == 0) {
-            super.close();
-        }
     }
 
     @Override
@@ -206,9 +195,6 @@ class Database extends SQLiteOpenHelper {
                             COLUMN_DATE_AND_HOUR + " != ? and " +
                                     COLUMN_IS_RECORDED_ON_SERVER + " = ?", new String[]{"-1", "0"}, null, null, null);
             Logger.log("Not recoreded Chunk Size: " + c.getCount());
-            if (c == null) {
-                return new ArrayList<>();
-            }
             // cursor close is in method
             return createChunkedStepCounts(c);
         } catch (Exception e) {

--- a/src/main/java/com/sukesan1984/stepsensorlib/PreferenceManager.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/PreferenceManager.java
@@ -4,11 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 
-/**
- * Created by kosuketakami on 2017/01/16.
- */
-
-public class PreferenceManager {
+// TODO: use this for service restart
+class PreferenceManager {
     private static String PEDOMETER = "pedometer";
     private static String CORRECT_SHUTDOWN = "corretctShutdown";
     private static String STEPS_SINCE_BOOT = "stepsSinceBoot";

--- a/src/main/java/com/sukesan1984/stepsensorlib/SensorListener.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/SensorListener.java
@@ -52,9 +52,9 @@ public class SensorListener extends Service implements SensorEventListener {
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
+    public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
         Logger.log("################################## onStartCommand called ####################################");
-        if (intent.getBooleanExtra(EXTRA_RESET_DATA, false)) {
+        if (intent != null && intent.getBooleanExtra(EXTRA_RESET_DATA, false)) {
             Logger.log("Deleting all data and stopping service.");
             unregisterSensor();
             StepCountCoordinator.getInstance().reset();

--- a/src/main/java/com/sukesan1984/stepsensorlib/ShutdownReceiver.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/ShutdownReceiver.java
@@ -5,30 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.sukesan1984.stepsensorlib.util.Logger;
-import com.sukesan1984.stepsensorlib.util.SensorListener;
-
-/**
- * Created by kosuketakami on 2016/11/05.
- */
 
 public class ShutdownReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (BuildConfig.DEBUG) Logger.log("shutting down");
-
-        context.startService(new Intent(context, SensorListener.class));
-
-        // if the user used a root script for shutdown, the DEVICE_SHUTDOWN
-        // broadcast might not be send. Thereforee, the app will check this
-        // setting on the next boot and displays an error message if it's not
-        // set to true
-        PreferenceManager.writeCorrectShutDown(context, true);
-
-        Database db = Database.getInstance(context);
-
-        db.resetLastUpdatedSteps(db.getLastUpdatedSteps());
-        if (BuildConfig.DEBUG) db.logState();
-
-        db.close();
+        StepCountCoordinator.getInstance().saveSteps(context);
     }
 }

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -47,8 +47,8 @@ class StepCountCoordinator {
         if (newSteps < 0) {
             Log.e(TAG, "Failed to save steps.");
         } else {
+            stepsOffset += unsavedSteps;
             unsavedSteps = 0;
-            stepsOffset = newSteps;
         }
         database.close();
     }

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -62,7 +62,6 @@ class StepCountCoordinator {
         } else {
             unsavedSteps = 0;
         }
-        database.close();
     }
 
     public synchronized int getTodaySteps(Context context) {

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -41,8 +41,9 @@ class StepCountCoordinator {
 
     public synchronized void saveSteps(Context context) {
         if (dateAndHourOfLastEvent == null) return;
-        Database database = Database.getInstance(context);
         Log.v(TAG, "saveSteps: " + unsavedSteps);
+        if (unsavedSteps == 0) return;
+        Database database = Database.getInstance(context);
         int newSteps = database.addSteps(dateAndHourOfLastEvent, unsavedSteps);
         if (newSteps < 0) {
             Log.e(TAG, "Failed to save steps.");

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -61,4 +61,10 @@ class StepCountCoordinator {
         }
         return Database.getInstance(context).getTodayStep() + unsavedSteps;
     }
+
+    public synchronized void reset() {
+        dateAndHourOfLastEvent = null;
+        stepsOffset = 0;
+        unsavedSteps = 0;
+    }
 }

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -34,7 +34,7 @@ class StepCountCoordinator {
         if (dateAndHourOfLastEvent == null) {
             dateAndHourOfLastEvent = dateAndHour;
             stepsOffset = stepsSinceBoot;
-            Log.v(TAG, "onStepSensorEvent: stepsOffset is set to " + unsavedSteps);
+            Log.v(TAG, "onStepCounterEvent: stepsOffset is set to " + stepsOffset);
             return;
         }
 
@@ -42,7 +42,7 @@ class StepCountCoordinator {
             saveSteps(context);
         }
         unsavedSteps = stepsSinceBoot - stepsOffset;
-        Log.v(TAG, "onStepSensorEvent: " + unsavedSteps);
+        Log.v(TAG, "onStepCounterEvent: " + unsavedSteps);
         dateAndHourOfLastEvent = dateAndHour;
     }
 
@@ -50,10 +50,12 @@ class StepCountCoordinator {
         if (dateAndHourOfLastEvent == null) return;
         Database database = Database.getInstance(context);
         Log.v(TAG, "saveSteps: " + unsavedSteps);
-        if (database.addSteps(dateAndHourOfLastEvent, unsavedSteps)) {
-            unsavedSteps = 0;
-        } else {
+        int newSteps = database.addSteps(dateAndHourOfLastEvent, unsavedSteps);
+        if (newSteps < 0) {
             Log.e(TAG, "Failed to save steps.");
+        } else {
+            unsavedSteps = 0;
+            stepsOffset = newSteps;
         }
         database.close();
     }

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -8,7 +8,7 @@ import com.sukesan1984.stepsensorlib.util.DateUtils;
 
 class StepCountCoordinator {
     private static final String TAG = "StepCountCoordinator";
-    private static volatile StepCountCoordinator singleton;
+    private static final StepCountCoordinator singleton = new StepCountCoordinator();
 
     @Nullable
     private Long dateAndHourOfLastEvent;
@@ -16,13 +16,6 @@ class StepCountCoordinator {
     private int unsavedSteps = 0;
 
     public static StepCountCoordinator getInstance() {
-        if (singleton == null) {
-            synchronized (StepCountCoordinator.class) {
-                if (singleton == null) {
-                    singleton = new StepCountCoordinator();
-                }
-            }
-        }
         return singleton;
     }
 

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepCountCoordinator.java
@@ -1,0 +1,69 @@
+package com.sukesan1984.stepsensorlib;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.sukesan1984.stepsensorlib.util.DateUtils;
+
+class StepCountCoordinator {
+    private static final String TAG = "StepCountCoordinator";
+    private static volatile StepCountCoordinator singleton;
+
+    @Nullable
+    private Long dateAndHourOfLastEvent;
+    private int stepsOffset;
+    private int unsavedSteps = 0;
+
+    public static StepCountCoordinator getInstance() {
+        if (singleton == null) {
+            synchronized (StepCountCoordinator.class) {
+                if (singleton == null) {
+                    singleton = new StepCountCoordinator();
+                }
+            }
+        }
+        return singleton;
+    }
+
+    private StepCountCoordinator() {
+    }
+
+    public synchronized void onStepCounterEvent(Context context, int stepsSinceBoot) {
+        long dateAndHour = DateUtils.getCurrentDateAndHour();
+        if (dateAndHourOfLastEvent == null) {
+            dateAndHourOfLastEvent = dateAndHour;
+            stepsOffset = stepsSinceBoot;
+            Log.v(TAG, "onStepSensorEvent: stepsOffset is set to " + unsavedSteps);
+            return;
+        }
+
+        if (dateAndHour != dateAndHourOfLastEvent) {
+            saveSteps(context);
+        }
+        unsavedSteps = stepsSinceBoot - stepsOffset;
+        Log.v(TAG, "onStepSensorEvent: " + unsavedSteps);
+        dateAndHourOfLastEvent = dateAndHour;
+    }
+
+    public synchronized void saveSteps(Context context) {
+        if (dateAndHourOfLastEvent == null) return;
+        Database database = Database.getInstance(context);
+        Log.v(TAG, "saveSteps: " + unsavedSteps);
+        if (database.addSteps(dateAndHourOfLastEvent, unsavedSteps)) {
+            unsavedSteps = 0;
+        } else {
+            Log.e(TAG, "Failed to save steps.");
+        }
+        database.close();
+    }
+
+    public synchronized int getTodaySteps(Context context) {
+        long dateAndHour = DateUtils.getCurrentDateAndHour();
+        if (dateAndHourOfLastEvent != null && dateAndHour != dateAndHourOfLastEvent) {
+            // Save and flush step count before fetch.
+            saveSteps(context);
+        }
+        return Database.getInstance(context).getTodayStep() + unsavedSteps;
+    }
+}

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
@@ -41,9 +41,9 @@ public class StepSensorFacade {
         context.startService(SensorListener.createIntentForReset(context));
     }
 
-    public static void increaseByChunkStepCounts(Context context, List<ChunkStepCount> chunkStepCounts) {
+    public static void increaseByServerChunkStepCounts(Context context, List<ChunkStepCount> chunkStepCounts) {
         saveNow(context);
-        Database.getInstance(context).increaseByChunkStepCounts(chunkStepCounts);
+        Database.getInstance(context).increaseByServerChunkStepCounts(chunkStepCounts);
     }
 
     @NonNull
@@ -56,14 +56,5 @@ public class StepSensorFacade {
     public static List<ChunkStepCount> getNotRecordedChunkStepCounts(Context context) {
         saveNow(context);
         return Database.getInstance(context).getNotRecordedChunkStepCounts();
-    }
-
-    public static void markChunkStepCountsAsRecorded(Context context, List<ChunkStepCount> chunkStepCounts) {
-        saveNow(context);
-        List<Long> dateAndHours = new ArrayList<>(chunkStepCounts.size());
-        for (ChunkStepCount chunkStepCount : chunkStepCounts) {
-            dateAndHours.add(chunkStepCount.unixTimeMillis);
-        }
-        Database.getInstance(context).updateToRecorded(dateAndHours);
     }
 }

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
@@ -3,15 +3,59 @@ package com.sukesan1984.stepsensorlib;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.support.annotation.NonNull;
+
+import com.sukesan1984.stepsensorlib.model.ChunkStepCount;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Step Sensor Facade
  */
 
 public class StepSensorFacade {
+    private StepSensorFacade() {
+        throw new AssertionError();
+    }
+
     public static boolean isValidStepSensorDevice(Context context) {
         // TODO: get from server side black list model.
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
                 && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER);
+    }
+
+    public static void startService(Context context) {
+        context.startService(SensorListener.createIntent(context));
+    }
+
+    public static int getTodaySteps(Context context) {
+        return StepCountCoordinator.getInstance().getTodaySteps(context);
+    }
+
+    public static void clearAllData(Context context) {
+        Database.getInstance(context).deleteAll();
+    }
+
+    public static void increaseByChunkStepCounts(Context context, List<ChunkStepCount> chunkStepCounts) {
+        Database.getInstance(context).increaseByChunkStepCounts(chunkStepCounts);
+    }
+
+    @NonNull
+    public static List<ChunkStepCount> getChunkStepsSince(Context context, long dateAndHour) {
+        return Database.getInstance(context).getChunkStepsSince(dateAndHour);
+    }
+
+    @NonNull
+    public static List<ChunkStepCount> getNotRecordedChunkStepCounts(Context context) {
+        return Database.getInstance(context).getNotRecordedChunkStepCounts();
+    }
+
+    public static void markChunkStepCountsAsRecorded(Context context, List<ChunkStepCount> chunkStepCounts) {
+        List<Long> dateAndHours = new ArrayList<>(chunkStepCounts.size());
+        for (ChunkStepCount chunkStepCount : chunkStepCounts) {
+            dateAndHours.add(chunkStepCount.unixTimeMillis);
+        }
+        Database.getInstance(context).updateToRecorded(dateAndHours);
     }
 }

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
@@ -34,7 +34,7 @@ public class StepSensorFacade {
     }
 
     public static void clearAllData(Context context) {
-        Database.getInstance(context).deleteAll();
+        context.startService(SensorListener.createIntentForReset(context));
     }
 
     public static void increaseByChunkStepCounts(Context context, List<ChunkStepCount> chunkStepCounts) {

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
@@ -25,7 +25,7 @@ public class StepSensorFacade {
                 && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER);
     }
 
-    public static void startService(Context context) {
+    public static void startServiceAndSaveData(Context context) {
         context.startService(SensorListener.createIntent(context));
     }
 

--- a/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
+++ b/src/main/java/com/sukesan1984/stepsensorlib/StepSensorFacade.java
@@ -25,8 +25,12 @@ public class StepSensorFacade {
                 && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER);
     }
 
-    public static void startServiceAndSaveData(Context context) {
+    public static void startService(Context context) {
         context.startService(SensorListener.createIntent(context));
+    }
+
+    public static void saveNow(Context context) {
+        StepCountCoordinator.getInstance().saveSteps(context);
     }
 
     public static int getTodaySteps(Context context) {
@@ -38,20 +42,24 @@ public class StepSensorFacade {
     }
 
     public static void increaseByChunkStepCounts(Context context, List<ChunkStepCount> chunkStepCounts) {
+        saveNow(context);
         Database.getInstance(context).increaseByChunkStepCounts(chunkStepCounts);
     }
 
     @NonNull
     public static List<ChunkStepCount> getChunkStepsSince(Context context, long dateAndHour) {
+        saveNow(context);
         return Database.getInstance(context).getChunkStepsSince(dateAndHour);
     }
 
     @NonNull
     public static List<ChunkStepCount> getNotRecordedChunkStepCounts(Context context) {
+        saveNow(context);
         return Database.getInstance(context).getNotRecordedChunkStepCounts();
     }
 
     public static void markChunkStepCountsAsRecorded(Context context, List<ChunkStepCount> chunkStepCounts) {
+        saveNow(context);
         List<Long> dateAndHours = new ArrayList<>(chunkStepCounts.size());
         for (ChunkStepCount chunkStepCount : chunkStepCounts) {
             dateAndHours.add(chunkStepCount.unixTimeMillis);


### PR DESCRIPTION
PoC implementation.
This does not rely on SharedPreferences or DB to store "current steps", and uses instance var instead.
As document of TYPE_STEP_COUNTER,

> Application needs to stay registered for this sensor because step counter does not count steps if it is not activated.

If app (service) is killed it does not increase the counter (except when other app is using the sensor). So we can just restart from sensor's current count.
(But we should save steps to DB frequently, otherwise data loss might be happen on service kill.)
TODO: Save it more frequently.

Other things:
- Service is exported unexpectedly, fixed it.
- Make interface other than StepSensorFacade private.
- Unify "mark as uploaded" and increase steps (by server data) operation and run them atomically.
- Add max steps at once limit to skip error sample.